### PR TITLE
Mark the repo as root in the editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,5 @@
+root = true
+
 [*]
 charset = utf-8
 


### PR DESCRIPTION
Necessary due to CR/LF mess, it shouldn’t inherit the LF setting from Minetest.